### PR TITLE
Correct 16 byte pointer alignment

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,9 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,4 @@ repository = "https://github.com/blt/bh_alloc"
 libc = "0.2"
 
 [dev-dependencies]
-quickcheck = "0.7"
 hashbrown = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh_alloc"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 keywords = ["fuzzing", "allocator"]
 categories = ["memory-management"]

--- a/src/fuzz/mod.rs
+++ b/src/fuzz/mod.rs
@@ -7,7 +7,7 @@
 extern crate libc;
 
 use self::libc::{_exit, EXIT_SUCCESS};
-use super::util::align_gt;
+use super::util::align;
 use std::alloc::{GlobalAlloc, Layout};
 use std::cell::UnsafeCell;
 
@@ -54,7 +54,7 @@ unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let offset = self.offset.get();
 
-        let start = align_gt(*offset, layout);
+        let start = align(*offset, layout.align());
         let end = start.saturating_add(layout.size());
 
         if end >= TOTAL_BYTES {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,44 +1,56 @@
-pub fn align(offset: usize, align_size_bytes: usize) -> usize {
-    if align_size_bytes == 0 {
-        return offset;
-    }
-
+pub fn align_diff(offset: usize, align_size_bytes: usize) -> usize {
     let rem = offset % align_size_bytes;
     if rem == 0 {
-        return offset;
+        return 0;
     }
 
-    (offset + align_size_bytes) - rem
+    align_size_bytes - rem
+
+    // if align_size_bytes == 0 {
+    //     return offset;
+    // }
+
+    // let rem = offset % align_size_bytes;
+    // if rem == 0 {
+    //     return offset;
+    // }
+
+    // (offset + align_size_bytes) - rem
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    // use quickcheck::{QuickCheck, TestResult};
-    use std::alloc::Layout;
-    use std::mem;
 
     #[test]
-    fn align_test() {
-        // Goal is to align allocations along double words, here 16 bytes.
-        let double_word_bytes = 16;
-        let mut offset = 0;
-        // The first allocation takes place at memory offset 16 and is for one
-        // byte. Expectation is that 0 bytes will need to be added to the offset
-        // to meet alignment.
-        assert_eq!(0, align(offset, double_word_bytes));
-        offset += 1;
-        // Okay, now, offset is 1 and we want to allocate another byte. We'll be
-        // scooted forward to the 16th byte.
-        assert_eq!(16, align(offset, double_word_bytes));
-        offset = 16;
-        offset += 1;
-        // Now the offset is 17 and a u32 is being allocated. We'll be scooted
-        // forward to the 32nd byte and the offset will be 36.
-        assert_eq!(32, align(offset, double_word_bytes));
-        offset = 32;
-        offset += 4;
-        // Now allocate another byte.
-        assert_eq!(48, align(offset, double_word_bytes));
+    fn align_diff_test() {
+        assert_eq!(0, align_diff(0, 16));
+        assert_eq!(0, align_diff(32, 16));
+        assert_eq!(0, align_diff(16, 16));
+        assert_eq!(3, align_diff(13, 16));
     }
+
+    // #[test]
+    // fn align_test() {
+    //     // Goal is to align allocations along double words, here 16 bytes.
+    //     let double_word_bytes = 16;
+    //     let mut offset = 0;
+    //     // The first allocation takes place at memory offset 16 and is for one
+    //     // byte. Expectation is that 0 bytes will need to be added to the offset
+    //     // to meet alignment.
+    //     assert_eq!(0, align(offset, double_word_bytes));
+    //     offset += 1;
+    //     // Okay, now, offset is 1 and we want to allocate another byte. We'll be
+    //     // scooted forward to the 16th byte.
+    //     assert_eq!(16, align(offset, double_word_bytes));
+    //     offset = 16;
+    //     offset += 1;
+    //     // Now the offset is 17 and a u32 is being allocated. We'll be scooted
+    //     // forward to the 32nd byte and the offset will be 36.
+    //     assert_eq!(32, align(offset, double_word_bytes));
+    //     offset = 32;
+    //     offset += 4;
+    //     // Now allocate another byte.
+    //     assert_eq!(48, align(offset, double_word_bytes));
+    // }
 }

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -11,7 +11,7 @@ fn hello_world() {
 
 #[test]
 fn alloc_and_destroy() {
-    for i in 0..5_000_000 {
+    for i in 0..5_000 {
         let bi = Box::new(i);
         drop(bi);
     }


### PR DESCRIPTION
This series of commits corrects the issue laid out in #2. Previously the offsets were being aligned, rather than the pointer underneath the offset. I've reduced the static allocation to 500 kibibytes to reduce link time and added a travis configuration. 

Closes #2 