### PR TITLE
Shift to nostd, remove BYTE_ALIGNMENT constant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "bh_alloc"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
-keywords = ["fuzzing", "allocator"]
+keywords = ["fuzzing", "allocator", "nostd"]
 categories = ["memory-management"]
 description = "A fuzzer friendly bump pointer allocator"
 license = "MIT"

--- a/src/fuzz/mod.rs
+++ b/src/fuzz/mod.rs
@@ -8,9 +8,9 @@ extern crate libc;
 
 use self::libc::{_exit, EXIT_SUCCESS};
 use super::util::align_diff;
-use super::{BYTE_ALIGNMENT, TOTAL_BYTES};
-use std::alloc::{GlobalAlloc, Layout};
-use std::cell::UnsafeCell;
+use super::TOTAL_BYTES;
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 
 /// Total number of bytes that [`BumpAlloc`] will have available to it.
 static mut HEAP: [u8; TOTAL_BYTES] = [0; TOTAL_BYTES];
@@ -54,7 +54,7 @@ unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let offset = self.offset.get();
 
-        let diff = align_diff(HEAP.as_mut_ptr().add(*offset) as usize, BYTE_ALIGNMENT);
+        let diff = align_diff(HEAP.as_mut_ptr().add(*offset) as usize, layout.align());
         let start = *offset + diff;
         let end = start.saturating_add(layout.size());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::pedantic))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::perf))]
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::style))]
+#![no_std]
 
 // #[cfg(test)]
 // extern crate quickcheck;
@@ -19,9 +20,9 @@
 pub mod fuzz;
 mod util;
 
-use std::alloc::{GlobalAlloc, Layout};
-use std::ptr;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use core::alloc::{GlobalAlloc, Layout};
+use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
 use util::align_diff;
 
 /// Total number of bytes that [`BumpAlloc`] will have available to it.
@@ -56,13 +57,11 @@ impl BumpAlloc {
     pub const INIT: Self = <Self as ConstInit>::INIT;
 }
 
-const BYTE_ALIGNMENT: usize = 16;
-
 unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mut offset = self.offset.load(Ordering::Relaxed);
         loop {
-            let diff = align_diff(HEAP.as_mut_ptr().add(offset) as usize, BYTE_ALIGNMENT);
+            let diff = align_diff(HEAP.as_mut_ptr().add(offset) as usize, layout.align());
             let start = offset + diff;
             let end = start.saturating_add(layout.size());
 


### PR DESCRIPTION
After @SimonSapin commented on #4 asking why I was using a BYTE_ALIGNMENT
constant rather than the alignment advertised by the Layout I realized that,
well, not only should I fix that but that I could also drop the reliance
on std.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>