### PR TITLE
Introduce dynamic allocation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bh_alloc"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 keywords = ["fuzzing", "allocator", "nostd"]
 categories = ["memory-management"]
@@ -14,3 +14,4 @@ libc = "0.2"
 
 [dev-dependencies]
 hashbrown = "0.1"
+rayon = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,17 @@ pub mod fuzz;
 mod util;
 
 use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 use core::ptr;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use core::sync::atomic::{
+    spin_loop_hint, AtomicBool, AtomicUsize, Ordering, ATOMIC_BOOL_INIT, ATOMIC_USIZE_INIT,
+};
 use util::align_diff;
 
+extern crate libc;
+
 /// Total number of bytes that [`BumpAlloc`] will have available to it.
-pub const TOTAL_BYTES: usize = 512_000; // 500 kibibytes
-static mut HEAP: [u8; TOTAL_BYTES] = [0; TOTAL_BYTES];
+pub const TOTAL_BYTES: usize = 5_048_576; // 5 mebibytes
 
 /// Bump allocator for multi-core systems
 ///
@@ -30,6 +34,8 @@ static mut HEAP: [u8; TOTAL_BYTES] = [0; TOTAL_BYTES];
 /// that memory is allocated at program start and never freed. This is very
 /// fast.
 pub struct BumpAlloc {
+    alloc_lock: AtomicBool,
+    memblk: UnsafeCell<*mut u8>,
     offset: AtomicUsize,
 }
 
@@ -43,7 +49,9 @@ trait ConstInit {
 
 impl ConstInit for BumpAlloc {
     const INIT: Self = Self {
-        offset: AtomicUsize::new(0),
+        alloc_lock: ATOMIC_BOOL_INIT,
+        memblk: UnsafeCell::new(ptr::null_mut()),
+        offset: ATOMIC_USIZE_INIT,
     };
 }
 
@@ -55,8 +63,39 @@ impl BumpAlloc {
 unsafe impl GlobalAlloc for BumpAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mut offset = self.offset.load(Ordering::Relaxed);
+
+        while (*self.memblk.get()).is_null() {
+            // first allocation, no prior call to mmap to get pages from OS
+            loop {
+                match self.alloc_lock.compare_exchange_weak(
+                    false,
+                    true,
+                    Ordering::Acquire,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => {
+                        let ptr = libc::mmap(
+                            0 as *mut libc::c_void,
+                            TOTAL_BYTES as libc::size_t,
+                            libc::PROT_READ | libc::PROT_WRITE,
+                            libc::MAP_ANON | libc::MAP_PRIVATE,
+                            -1,
+                            0 as libc::off_t,
+                        );
+                        if ptr == libc::MAP_FAILED {
+                            return ptr::null_mut();
+                        }
+                        *self.memblk.get() = ptr as *mut u8;
+                        self.alloc_lock.store(false, Ordering::Release);
+                        break;
+                    }
+                    Err(_) => spin_loop_hint(),
+                }
+            }
+        }
+
         loop {
-            let diff = align_diff(HEAP.as_mut_ptr().add(offset) as usize, layout.align());
+            let diff = align_diff((*self.memblk.get()).add(offset) as usize, layout.align());
             let start = offset + diff;
             let end = start.saturating_add(layout.size());
 
@@ -70,7 +109,7 @@ unsafe impl GlobalAlloc for BumpAlloc {
                     Ordering::Relaxed,
                 ) {
                     Ok(_) => {
-                        return HEAP[start..end].as_mut_ptr() as *mut u8;
+                        return (*self.memblk.get()).add(start);
                     }
                     Err(cur) => {
                         offset = cur;

--- a/tests/rayon.rs
+++ b/tests/rayon.rs
@@ -1,0 +1,19 @@
+extern crate bh_alloc;
+extern crate rayon;
+
+#[global_allocator]
+static ALLOC: bh_alloc::BumpAlloc = bh_alloc::BumpAlloc::INIT;
+
+use rayon::prelude::*;
+fn sum_of_squares(input: &[u16]) -> usize {
+    input
+        .par_iter() // <-- just change that!
+        .map(|&i| (i as usize) * (i as usize))
+        .sum()
+}
+
+#[test]
+fn doc_example() {
+    let input: Vec<u16> = (0..u16::max_value()).collect();
+    assert_eq!(93_818_549_927_935, sum_of_squares(&input));
+}


### PR DESCRIPTION
Previously the bump allocator used a constant, static array as an
allocated pool. This was nice in the sense that it was very easy to
produce but had a major downside in the link size of any executable
using bh_alloc. This is corrected by using mmap to get some heap space
on the first allocation of the system.

bh_alloc using programs should now be much smaller.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>